### PR TITLE
Add Singularity recipe for deeptools 3.5.6

### DIFF
--- a/damona/software/deeptools/Singularity.deeptools_3.5.6
+++ b/damona/software/deeptools/Singularity.deeptools_3.5.6
@@ -1,0 +1,30 @@
+Bootstrap: docker
+From: mambaorg/micromamba:1.5.8
+
+%labels
+    Author Damona Team
+    Version v3.5.6
+
+%post
+    apt-get update --fix-missing && apt-get install -y wget
+
+    export PATH=$PATH:/opt/conda/envs/main/bin/
+    export OPTS=" -q -c conda-forge -c bioconda -n main -y "
+
+    micromamba install $OPTS "deeptools==3.5.6"
+
+    micromamba clean --packages -y
+    micromamba clean --all -y
+    rm -rf /opt/conda/pkgs
+
+    apt-get autoremove --purge -y wget
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+
+%environment
+    export LC_ALL=C.UTF-8
+    export LANG=C.UTF-8
+    export PATH=$PATH:/opt/conda/envs/main/bin/
+
+%runscript
+    exec bamCoverage "$@"


### PR DESCRIPTION
### Motivation
- Provide a reproducible Singularity container for `deeptools==3.5.6` so tools like `bamCoverage` can be run in the project environment.

### Description
- Add `damona/software/deeptools/Singularity.deeptools_3.5.6` which bootstraps from `mambaorg/micromamba:1.5.8`, installs `deeptools==3.5.6` into a micromamba `main` environment, cleans package and APT caches, sets `LC_ALL`, `LANG` and updates `PATH`, and defines the runscript to `exec bamCoverage "$@"`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1ec40c83083278116cc4235f66503)